### PR TITLE
Add instructions in readme and fix CSV output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,24 @@ Will result in the creation of a log file per tag, with the default tag going to
 If you need only certain tags A,B:
 
     $ hodor SplitHistogramLogs -if taggyLog.hdr -it A -it B
+
+## HDR to CSV tool
+
+Using the above alias, run:
+
+    $ hodor HdrToCsv -i INPUT_FILE
+
+It will result in a strict transformation of a log file to CSV.  Intervals will
+be preserved.  For each interval, important percentiles will be written in
+dedicated columns.  The resulting CSV is printed on stdout.
+
+Example usage:
+
+```
+$ hodor HdrToCsv -i input.hgrm | tee output.csv
+#Timestamp,Throughput,Min,Avg,p50,p90,p95,p99,p999,p9999,Max
+1523292112.000,2364,60608,143515,113599,221823,268543,442367,1638399,6348799,6348799
+1523292113.000,192,64672,130923,116287,188031,205823,260351,366591,366591,366591
+1523292114.000,384,67520,144460,118527,213759,264703,414463,1793023,1793023,1793023
+...
+```

--- a/src/main/java/HdrToCsv.java
+++ b/src/main/java/HdrToCsv.java
@@ -6,6 +6,7 @@ import org.kohsuke.args4j.Option;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 public class HdrToCsv
 {
@@ -50,17 +51,18 @@ public class HdrToCsv
         while (reader.hasNext())
         {
             Histogram interval = (Histogram) reader.nextIntervalHistogram();
-            System.out.println(interval.getStartTimeStamp() + "," +
-                               interval.getTotalCount() + "," +
-                               interval.getMinValue() + "," +
-                               ((long) interval.getMean()) + "," +
-                               interval.getValueAtPercentile(50) + "," +
-                               interval.getValueAtPercentile(90) + "," +
-                               interval.getValueAtPercentile(95) + "," +
-                               interval.getValueAtPercentile(99) + "," +
-                               interval.getValueAtPercentile(99.9) + "," +
-                               interval.getValueAtPercentile(99.99) + "," +
-                               interval.getMaxValue());
+            System.out.printf(Locale.US,
+                    "%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d%n",
+                    interval.getStartTimeStamp() / 1000.0,
+                    interval.getTotalCount(), interval.getMinValue(),
+                    (long) interval.getMean(),
+                    interval.getValueAtPercentile(50),
+                    interval.getValueAtPercentile(90),
+                    interval.getValueAtPercentile(95),
+                    interval.getValueAtPercentile(99),
+                    interval.getValueAtPercentile(99.9),
+                    interval.getValueAtPercentile(99.99),
+                    interval.getMaxValue());
         }
     }
 }


### PR DESCRIPTION
The CSV output used millisecond timestamps as longs instead of the exact
same timestamps from HDR, as doubles.  This PR contains a ninja fix for
that.  The example in README shows the output with double timestamps.