### PR TITLE
Consume Input stream instead of file in split and to-csv

### DIFF
--- a/src/main/java/HdrToCsv.java
+++ b/src/main/java/HdrToCsv.java
@@ -2,10 +2,7 @@ import org.HdrHistogram.Histogram;
 import org.kohsuke.args4j.Option;
 import psy.lob.saw.OrderedHistogramLogReader;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Paths;
 import java.util.Locale;
 
@@ -38,30 +35,45 @@ public class HdrToCsv implements Runnable
     {
         try(InputStream inputStream = new FileInputStream(inputFile))
         {
-            OrderedHistogramLogReader reader = new OrderedHistogramLogReader(inputStream);
-            System.out.println(
-                "#Absolute timestamp,Relative timestamp,Throughput,Min,Avg,p50,p90,p95,p99,p999,p9999,Max");
-            while (reader.hasNext())
-            {
-                Histogram interval = (Histogram) reader.nextIntervalHistogram();
-                System.out.printf(Locale.US,
-                    "%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d%n",
-                    interval.getStartTimeStamp() / 1000.0,
-                    interval.getStartTimeStamp() / 1000 - (long) reader.getStartTimeSec(),
-                    interval.getTotalCount(), interval.getMinValue(),
-                    (long) interval.getMean(),
-                    interval.getValueAtPercentile(50),
-                    interval.getValueAtPercentile(90),
-                    interval.getValueAtPercentile(95),
-                    interval.getValueAtPercentile(99),
-                    interval.getValueAtPercentile(99.9),
-                    interval.getValueAtPercentile(99.99),
-                    interval.getMaxValue());
-            }
+            new Converter(inputStream).convert();
         }
         catch (IOException e)
         {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static class Converter
+    {
+        private final InputStream inputStream;
+
+        public Converter(InputStream inputStream)
+        {
+            this.inputStream = inputStream;
+        }
+
+        public void convert() throws FileNotFoundException
+        {
+            OrderedHistogramLogReader reader = new OrderedHistogramLogReader(inputStream);
+            System.out.println(
+                    "#Absolute timestamp,Relative timestamp,Throughput,Min,Avg,p50,p90,p95,p99,p999,p9999,Max");
+            while (reader.hasNext())
+            {
+                Histogram interval = (Histogram) reader.nextIntervalHistogram();
+                System.out.printf(Locale.US,
+                        "%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d%n",
+                        interval.getStartTimeStamp() / 1000.0,
+                        interval.getStartTimeStamp() / 1000 - (long) reader.getStartTimeSec(),
+                        interval.getTotalCount(), interval.getMinValue(),
+                        (long) interval.getMean(),
+                        interval.getValueAtPercentile(50),
+                        interval.getValueAtPercentile(90),
+                        interval.getValueAtPercentile(95),
+                        interval.getValueAtPercentile(99),
+                        interval.getValueAtPercentile(99.9),
+                        interval.getValueAtPercentile(99.99),
+                        interval.getMaxValue());
+            }
         }
     }
 }

--- a/src/main/java/HdrToCsv.java
+++ b/src/main/java/HdrToCsv.java
@@ -33,7 +33,7 @@ public class HdrToCsv implements Runnable
     {
         try(InputStream inputStream = new FileInputStream(inputFile))
         {
-            new CsvConverter(inputStream).convert();
+            new CsvConverter(inputStream, System.out).convert();
         }
         catch (IOException e)
         {

--- a/src/main/java/HdrToCsv.java
+++ b/src/main/java/HdrToCsv.java
@@ -1,10 +1,8 @@
-import org.HdrHistogram.Histogram;
 import org.kohsuke.args4j.Option;
-import psy.lob.saw.OrderedHistogramLogReader;
+import psy.lob.saw.CsvConverter;
 
 import java.io.*;
 import java.nio.file.Paths;
-import java.util.Locale;
 
 public class HdrToCsv implements Runnable
 {
@@ -35,45 +33,11 @@ public class HdrToCsv implements Runnable
     {
         try(InputStream inputStream = new FileInputStream(inputFile))
         {
-            new Converter(inputStream).convert();
+            new CsvConverter(inputStream).convert();
         }
         catch (IOException e)
         {
             throw new RuntimeException(e);
-        }
-    }
-
-    public static class Converter
-    {
-        private final InputStream inputStream;
-
-        public Converter(InputStream inputStream)
-        {
-            this.inputStream = inputStream;
-        }
-
-        public void convert() throws FileNotFoundException
-        {
-            OrderedHistogramLogReader reader = new OrderedHistogramLogReader(inputStream);
-            System.out.println(
-                    "#Absolute timestamp,Relative timestamp,Throughput,Min,Avg,p50,p90,p95,p99,p999,p9999,Max");
-            while (reader.hasNext())
-            {
-                Histogram interval = (Histogram) reader.nextIntervalHistogram();
-                System.out.printf(Locale.US,
-                        "%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d%n",
-                        interval.getStartTimeStamp() / 1000.0,
-                        interval.getStartTimeStamp() / 1000 - (long) reader.getStartTimeSec(),
-                        interval.getTotalCount(), interval.getMinValue(),
-                        (long) interval.getMean(),
-                        interval.getValueAtPercentile(50),
-                        interval.getValueAtPercentile(90),
-                        interval.getValueAtPercentile(95),
-                        interval.getValueAtPercentile(99),
-                        interval.getValueAtPercentile(99.9),
-                        interval.getValueAtPercentile(99.99),
-                        interval.getMaxValue());
-            }
         }
     }
 }

--- a/src/main/java/SplitHistogramLogs.java
+++ b/src/main/java/SplitHistogramLogs.java
@@ -4,6 +4,7 @@ import psy.lob.saw.HistogramsSplitter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -23,6 +24,7 @@ public class SplitHistogramLogs implements Runnable
     private File inputFile;
     private Set<String> excludeTags = new HashSet<>();
     private Set<String> includeTags = new HashSet<>();
+    private String fileName;
 
     public static void main(String[] args) throws Exception
     {
@@ -89,7 +91,9 @@ public class SplitHistogramLogs implements Runnable
         }
         try(InputStream inputStream = new FileInputStream(inputFile))
         {
-            new HistogramsSplitter(inputFile.getName(), inputStream, start, end, verbose, this::shouldSkipTag).split();
+            Path outputDir = inputFile.toPath().getParent();
+            fileName = inputFile.getName();
+            new HistogramsSplitter(fileName, inputStream, start, end, verbose, this::shouldSkipTag, outputDir).split();
         }
         catch (Exception e)
         {

--- a/src/main/java/UnionHistogramLogs.java
+++ b/src/main/java/UnionHistogramLogs.java
@@ -6,9 +6,7 @@ import psy.lob.saw.HistogramSink;
 import psy.lob.saw.OrderedHistogramLogReader;
 import psy.lob.saw.UnionHistograms;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
+import java.io.*;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -152,10 +150,13 @@ public class UnionHistogramLogs implements Runnable
             List<HistogramIterator> ins = new ArrayList<>();
             for (File inputFile : inputFiles)
             {
-                ins.add(new HistogramIterator(
-                    new OrderedHistogramLogReader(inputFile, start, end),
-                    inputFilesTags.get(inputFile),
-                    relative));
+                try(InputStream inputStream = new FileInputStream(inputFile))
+                {
+                    ins.add(new HistogramIterator(
+                            new OrderedHistogramLogReader(inputStream, start, end),
+                            inputFilesTags.get(inputFile),
+                            relative));
+                }
             }
             UnionHistograms unionHistograms = new UnionHistograms(verbose, System.out, ins, new HistogramSink()
             {

--- a/src/main/java/psy/lob/saw/CsvConverter.java
+++ b/src/main/java/psy/lob/saw/CsvConverter.java
@@ -1,0 +1,41 @@
+package psy.lob.saw;
+
+import org.HdrHistogram.Histogram;
+
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Locale;
+
+public class CsvConverter
+{
+    private final InputStream inputStream;
+
+    public CsvConverter(InputStream inputStream)
+    {
+        this.inputStream = inputStream;
+    }
+
+    public void convert() throws FileNotFoundException
+    {
+        OrderedHistogramLogReader reader = new OrderedHistogramLogReader(inputStream);
+        System.out.println(
+                "#Absolute timestamp,Relative timestamp,Throughput,Min,Avg,p50,p90,p95,p99,p999,p9999,Max");
+        while (reader.hasNext())
+        {
+            Histogram interval = (Histogram) reader.nextIntervalHistogram();
+            System.out.printf(Locale.US,
+                    "%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d%n",
+                    interval.getStartTimeStamp() / 1000.0,
+                    interval.getStartTimeStamp() / 1000 - (long) reader.getStartTimeSec(),
+                    interval.getTotalCount(), interval.getMinValue(),
+                    (long) interval.getMean(),
+                    interval.getValueAtPercentile(50),
+                    interval.getValueAtPercentile(90),
+                    interval.getValueAtPercentile(95),
+                    interval.getValueAtPercentile(99),
+                    interval.getValueAtPercentile(99.9),
+                    interval.getValueAtPercentile(99.99),
+                    interval.getMaxValue());
+        }
+    }
+}

--- a/src/main/java/psy/lob/saw/CsvConverter.java
+++ b/src/main/java/psy/lob/saw/CsvConverter.java
@@ -4,26 +4,29 @@ import org.HdrHistogram.Histogram;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.util.Locale;
 
 public class CsvConverter
 {
     private final InputStream inputStream;
+    private final PrintStream outputStream;
 
-    public CsvConverter(InputStream inputStream)
+    public CsvConverter(InputStream inputStream, PrintStream outputStream)
     {
         this.inputStream = inputStream;
+        this.outputStream = outputStream;
     }
 
     public void convert() throws FileNotFoundException
     {
         OrderedHistogramLogReader reader = new OrderedHistogramLogReader(inputStream);
-        System.out.println(
+        outputStream.println(
                 "#Absolute timestamp,Relative timestamp,Throughput,Min,Avg,p50,p90,p95,p99,p999,p9999,Max");
         while (reader.hasNext())
         {
             Histogram interval = (Histogram) reader.nextIntervalHistogram();
-            System.out.printf(Locale.US,
+            outputStream.printf(Locale.US,
                     "%.3f,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d%n",
                     interval.getStartTimeStamp() / 1000.0,
                     interval.getStartTimeStamp() / 1000 - (long) reader.getStartTimeSec(),

--- a/src/main/java/psy/lob/saw/HistogramsSplitter.java
+++ b/src/main/java/psy/lob/saw/HistogramsSplitter.java
@@ -1,0 +1,75 @@
+package psy.lob.saw;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static psy.lob.saw.HdrHistogramUtil.logHistogramForVerbose;
+
+public class HistogramsSplitter
+{
+    private final String inputFileName;
+    private final InputStream inputStream;
+    private final double start;
+    private final double end;
+    private final boolean verbose;
+    private final Predicate<String> tagExclusionPredicate;
+
+    public HistogramsSplitter(String inputFileName, InputStream inputStream,
+                              double start, double end,
+                              boolean verbose, Predicate<String> tagExclusionPredicate)
+    {
+        this.inputFileName = inputFileName;
+        this.inputStream = inputStream;
+        this.start = start;
+        this.end = end;
+        this.verbose = verbose;
+        this.tagExclusionPredicate = tagExclusionPredicate;
+    }
+
+    public void split() throws FileNotFoundException
+    {
+        OrderedHistogramLogReader reader = new OrderedHistogramLogReader(
+                inputStream,
+                start,
+                end,
+                tagExclusionPredicate);
+        Map<String, HistogramLogWriter> writerByTag = new HashMap<>();
+        Histogram interval;
+        int i = 0;
+        while (reader.hasNext())
+        {
+            interval = (Histogram) reader.nextIntervalHistogram();
+            if (interval == null)
+            {
+                continue;
+            }
+            String ntag = interval.getTag();
+            if (tagExclusionPredicate.test(ntag))
+            {
+                throw new IllegalStateException("Should be filtered upfront by the reader");
+            }
+            if (this.verbose)
+            {
+                logHistogramForVerbose(System.out, interval, i++);
+            }
+            interval.setTag(null);
+            HistogramLogWriter writer = writerByTag.computeIfAbsent(ntag, k -> createWriterForTag(reader, k, inputFileName));
+            writer.outputIntervalHistogram(interval);
+        }
+    }
+
+    private HistogramLogWriter createWriterForTag(OrderedHistogramLogReader reader, String tag, String inputFileName)
+    {
+        tag = (tag == null) ? "default" : tag;
+        File outputFile = new File(tag + "." + inputFileName);
+        String comment = "Splitting of:" + inputFileName + " start:" + start + " end:" + end;
+        return HdrHistogramUtil.createLogWriter(outputFile, comment, reader.getStartTimeSec());
+    }
+}

--- a/src/main/java/psy/lob/saw/OrderedHistogramLogReader.java
+++ b/src/main/java/psy/lob/saw/OrderedHistogramLogReader.java
@@ -10,8 +10,8 @@ package psy.lob.saw;
 import org.HdrHistogram.EncodableHistogram;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.function.Predicate;
 import java.util.zip.DataFormatException;
 
@@ -143,26 +143,26 @@ public class OrderedHistogramLogReader implements Closeable
     private EncodableHistogram nextHistogram;
     private boolean inRange = true;
 
-    public OrderedHistogramLogReader(final File inputFile) throws FileNotFoundException
+    public OrderedHistogramLogReader(final InputStream inputStream) throws FileNotFoundException
     {
-        this(inputFile, 0.0, Long.MAX_VALUE * 1.0, s -> false, false);
+        this(inputStream, 0.0, Long.MAX_VALUE * 1.0, s -> false, false);
     }
 
-    public OrderedHistogramLogReader(File inputFile, double start, double end) throws FileNotFoundException
+    public OrderedHistogramLogReader(InputStream inputStream, double start, double end) throws FileNotFoundException
     {
-        this(inputFile, start, end, s -> false, false);
+        this(inputStream, start, end, s -> false, false);
     }
 
-    public OrderedHistogramLogReader(File inputFile, double start, double end, Predicate<String> shouldExcludeTag)
+    public OrderedHistogramLogReader(InputStream inputStream, double start, double end, Predicate<String> shouldExcludeTag)
         throws FileNotFoundException
     {
-        this(inputFile, start, end, shouldExcludeTag, false);
+        this(inputStream, start, end, shouldExcludeTag, false);
     }
 
     /**
      * Constructs a new OrderedHistogramLogReader that produces intervals read from the specified file.
      *
-     * @param inputFile         The File to read from
+     * @param inputStream       The data stream to read from
      * @param rangeStartTimeSec
      * @param rangeEndTimeSec
      * @param shouldExcludeTag  predicate returns true is tag should be skipped
@@ -170,12 +170,12 @@ public class OrderedHistogramLogReader implements Closeable
      * @throws FileNotFoundException when unable to find inputFile
      */
     public OrderedHistogramLogReader(
-        final File inputFile,
+        final InputStream inputStream,
         double rangeStartTimeSec,
         double rangeEndTimeSec,
         Predicate<String> shouldExcludeTag, boolean absolute) throws FileNotFoundException
     {
-        scanner = new HistogramLogScanner(inputFile);
+        scanner = new HistogramLogScanner(inputStream);
         this.rangeStartTimeSec = rangeStartTimeSec;
         this.rangeEndTimeSec = rangeEndTimeSec;
         this.absolute = absolute;


### PR DESCRIPTION
I recommend to tick the `Hide whitespace changes` box when reviewing this PR.

This PR is about making sure that `OrderedHistogramLogReader` consumes an `InputStream` instead of a `File`.  The change does not impact a lot of the codebase, as `HistogramLogScanner` already supports reading from an `InputStream`.

The main advantage is that if a Java application processes a file that is compressed, the `GZIPInputStream` can be passed straight away to HdrLogProcessing instead of decompressing in a temporary file.

To enable this ^ use case, the `SplitHistogramLogs` and `HdrToCsv` logics are extracted to a dedicated class.  This makes it possible to include HdrLogProcessing as a library, rather than only use it from the command line.